### PR TITLE
Add Ansible meta information to allow installing through Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: Stefan Hornburg
   description: Role to install Sympa. 
-  # license: tbd.
+  license: GPL-2.0
   min_ansible_version: "2.5"
   namespace: racke
   role_name: sympa

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,38 @@
+---
+galaxy_info:
+  author: Stefan Hornburg
+  description: Role to install Sympa. 
+  # license: tbd.
+  min_ansible_version: "2.5"
+  namespace: racke
+  role_name: sympa
+
+  platforms:
+    - name: ArchLinux
+    - name: opensuse
+      versions:
+        - "15.0"
+    - name: EL
+      versions:
+        - "7"
+        - "8"
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+        - buster
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+        - focal
+        - jammy
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+
+  galaxy_tags:
+    - sympa
+
+dependencies: []


### PR DESCRIPTION
Add Ansible meta information to allow installing using Ansible Galaxy: `ansible-galaxy install -r requirements.yml`.
Currently, I receive the issue:

`[WARNING]: - racke.sympa was NOT installed successfully: this role does not appear to have a meta/main.yml file`

Using the `requirements.yml`:

```yml
---
roles:
  - name: racke.sympa
    src: https://github.com/sympa-community/ansible-role-sympa.git
    scm: git
    version: main
```