### PR TITLE
LDAP requirements integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ Protocol for SOAP URL. Defaults to `https`.
 
 Number of FCGI instances (default: 2)
 
+### LDAP
+
+#### *sympa_ldap_auth_enabled*
+
+Whether authentication through LDAP is enabled. Defaults to `false`.
+
+#### *sympa_ldap_auth_secure*
+
+Whether authentication through LDAP is secure. Defaults to `true`.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,10 +134,14 @@ sympa_soap_fcgi_enabled: false
 sympa_soap_fcgi_protocol: https
 sympa_soap_fcgi_instances: 2
 
+sympa_ldap_auth_enabled: false
+sympa_ldap_auth_secure: true
+
 sympa_web_nginx_snippet: |
   location = / {
     return 301 /{{ sympa_web_path }};
   }
+
   location /{{ sympa_web_path }} {
     include fastcgi_params;
     fastcgi_pass  unix:{{ sympa_web_fcgi_socket }};

--- a/tasks/perl-modules.yml
+++ b/tasks/perl-modules.yml
@@ -55,9 +55,22 @@
 - name: Add SOAP to features if SOAP interface is enabled
   set_fact:
     sympa_cpanm_features: "{{ sympa_cpanm_features + ['soap'] }}"
-  when: sympa_soap_fcgi_enabled
+  when: sympa_soap_fcgi_enabled | bool
   tags: sympasoap
+
+- name: Add ldap-secure to features if LDAP auth is enabled
+  set_fact:
+    sympa_cpanm_features: "{{ sympa_cpanm_features + ['ldap-secure'] }}"
+  when: sympa_ldap_auth_enabled | bool
+  tags: sympaldap
+
+- name: Print features before install
+  ansible.builtin.debug:
+    var: sympa_cpanm_features
+    verbosity: 1
 
 - name: Install Perl modules with cpanm
   command: "{{ sympa_cpanm_program }} --notest --installdeps {{ sympa_source_directory }}{% for feature in sympa_cpanm_features %}  --with-feature {{ feature }}{% endfor %}"
-  tags: sympasoap
+  tags:
+  - sympasoap
+  - sympaldap

--- a/tasks/perl-modules.yml
+++ b/tasks/perl-modules.yml
@@ -42,6 +42,14 @@
     name: "{{ sympa_openssldev_package }}"
   when: sympa_config_dkim_feature or sympa_soap_fcgi_enabled
 
+- name: Install SSL development library and zlib development needed for LDAP
+  package:
+    name:
+      - "{{ sympa_openssldev_package }}"
+      - "{{ sympa_zlibdev_package }}"
+  when: sympa_ldap_auth_enabled | bool
+  tags: sympaldap
+
 - name: Add Mail::DKIM::Verifier to features if DKIM support is requested
   set_fact:
     sympa_cpanm_features: "{{ sympa_cpanm_features + ['Mail::DKIM::Verifier'] }}"

--- a/tasks/perl-modules.yml
+++ b/tasks/perl-modules.yml
@@ -47,7 +47,7 @@
     name:
       - "{{ sympa_openssldev_package }}"
       - "{{ sympa_zlibdev_package }}"
-  when: sympa_ldap_auth_enabled | bool
+  when: sympa_ldap_auth_enabled and sympa_ldap_auth_secure
   tags: sympaldap
 
 - name: Add Mail::DKIM::Verifier to features if DKIM support is requested
@@ -63,19 +63,20 @@
 - name: Add SOAP to features if SOAP interface is enabled
   set_fact:
     sympa_cpanm_features: "{{ sympa_cpanm_features + ['soap'] }}"
-  when: sympa_soap_fcgi_enabled | bool
+  when: sympa_soap_fcgi_enabled
   tags: sympasoap
 
-- name: Add ldap-secure to features if LDAP auth is enabled
+- name: Add ldap-secure to features if LDAP (ssl) auth is enabled
   set_fact:
     sympa_cpanm_features: "{{ sympa_cpanm_features + ['ldap-secure'] }}"
-  when: sympa_ldap_auth_enabled | bool
+  when: sympa_ldap_auth_enabled and sympa_ldap_auth_secure
   tags: sympaldap
 
-- name: Print features before install
-  ansible.builtin.debug:
-    var: sympa_cpanm_features
-    verbosity: 1
+- name: Add ldap to features if LDAP (no SSL) auth is enabled
+  set_fact:
+    sympa_cpanm_features: "{{ sympa_cpanm_features + ['ldap'] }}"
+  when: sympa_ldap_auth_enabled and not sympa_ldap_auth_secure
+  tags: sympaldap
 
 - name: Install Perl modules with cpanm
   command: "{{ sympa_cpanm_program }} --notest --installdeps {{ sympa_source_directory }}{% for feature in sympa_cpanm_features %}  --with-feature {{ feature }}{% endfor %}"


### PR DESCRIPTION
I propose the way we solved LDAP at my organization, where we build sympa from source and specify authentication directly through `sympa_web_authentication`. I'd appreciate hearing back from the community, particularly in relation to this PR and #5. Thank you!